### PR TITLE
Added alerted to addJoker

### DIFF
--- a/balamod/apis/center_hook.lua
+++ b/balamod/apis/center_hook.lua
@@ -205,7 +205,7 @@ function initCenterHook()
 
 
     --wip wip wip
-    function centerHook:addJoker(id, name, use_effect, order, unlocked, discovered, cost, pos, effect, config, desc, rarity, blueprint_compat, eternal_compat, no_pool_flag, yes_pool_flag, unlock_condition)
+    function centerHook:addJoker(id, name, use_effect, order, unlocked, discovered, cost, pos, effect, config, desc, rarity, blueprint_compat, eternal_compat, no_pool_flag, yes_pool_flag, unlock_condition, alerted)
         --defaults
         id = id or "j_Joker_Placeholder" .. #G.P_CENTER_POOLS["Joker"] + 1
         name = name or "Joker Placeholder"
@@ -224,6 +224,7 @@ function initCenterHook()
         no_pool_flag = no_pool_flag or nil
         yes_pool_flag = yes_pool_flag or nil
         unlock_condition = unlock_condition or nil
+        alerted = alerted or true
         
         --joker object
         local newJoker = {
@@ -242,7 +243,8 @@ function initCenterHook()
             eternal_compat = eternal_compat,
             no_pool_flag = no_pool_flag,
             yes_pool_flag = yes_pool_flag,
-            unlock_condition = unlock_condition
+            unlock_condition = unlock_condition, 
+            alerted = true
         }
     
         --add it to all the game tables


### PR DESCRIPTION
Theres an "alerted" property that gets set by the system when you hovered over the card in the collection screen.
When i didn't set this, it always showed the little red "!" on the card as if i just got it.
You can set this here to avoid this issue.

I don't know if this is the same with other centers, you might wanna check that (i have no way to do that right now) :D